### PR TITLE
Update Readme to add error interceptor detail

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ Example:
           },
           error: function ({getState, dispatch, getSourceAction}, error) {
             //...
+            return Promise.reject(error)
           }
         }
         ]


### PR DESCRIPTION
I faced few problems without this line and it was hard to find on the web.
With just a return error, errors are handled as success by redux